### PR TITLE
Option to Not Import "Simple" Models; Cleanup

### DIFF
--- a/bpy_lattice/constants.py
+++ b/bpy_lattice/constants.py
@@ -1,0 +1,36 @@
+
+ELE_X_SCALE_FACTOR = 50
+
+
+ELE_X_SCALE = {
+    "MARKER": 0.001,
+    "E_GUN": 0.4,
+    "PIPE": 0.01,
+    "DRIFT": 0.01,
+    "ECOLLIMATOR": 0.03,
+    "RCOLLIMATOR": 0.03,
+    "SBEND": 0.02,
+    "QUADRUPOLE": 0.03,
+    "SEXTUPOLE": 0.02,
+    "LCAVITY": 0.1,
+    "RFCAVITY": 0.5,
+    "SOLENOID": 0.1,
+    "WIGGLER": 0.04,
+    "EM_FIELD": 0.1,
+    "INSTRUMENT": 0.05,
+}
+
+
+ELE_COLOR = {
+    "PIPE": (1, 1, 1),
+    "E_GUN": (0.5, 0.5, 0.5),
+    "SBEND": (1, 0, 0),
+    "QUADRUPOLE": (0, 0, 1),
+    "LCAVITY": (0, 1, 0),
+    "RFCAVITY": (0, 1, 0),
+    "SOLENOID": (1, 0, 1),
+    "EM_FIELD": (1, 0, 0.5),
+    "SEXTUPOLE": (1, 1, 0),
+    "WIGGLER": (1, 0.4, 0),
+    "INSTRUMENT": (0, 0, 0),
+}

--- a/bpy_lattice/elements.py
+++ b/bpy_lattice/elements.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+from typing import Union
+
+
+@dataclass
+class Element:
+    name: str
+    index: int
+    x: float
+    y: float
+    z: float
+    theta: float
+    phi: float
+    psi: float
+    key: str
+    L: float
+    descrip: str
+
+
+@dataclass
+class SBend(Element):
+    angle: float
+    e1: float
+    e2: float
+
+
+@dataclass
+class Pipe(Element):
+    radius_x: float
+    radius_y: float
+    thickness: float
+
+
+@dataclass
+class Wiggler(Element):
+    radius_x: float
+    radius_y: float
+
+
+def map_table_element(line: str) -> Union[SBend, Pipe, Wiggler, Element]:
+    """Maps a comma-separated line to the appropriate beamline element dataclass."""
+    vals = line.split(",")[0:14]
+    
+    # Common parameters for all elements
+    base_params = {
+        "name": vals[0].strip(),
+        "index": int(vals[1]),
+        "x": float(vals[2]),
+        "y": float(vals[3]),
+        "z": float(vals[4]),
+        "theta": float(vals[5]),
+        "phi": float(vals[6]),
+        "psi": float(vals[7]),
+        "key": vals[8].strip().upper(),
+        "L": float(vals[9]),
+        "descrip": vals[13]
+    }
+    
+    element_type = base_params["key"]
+    
+    if element_type == "SBEND":
+        return SBend(
+            **base_params,
+            angle=float(vals[10]),
+            e1=float(vals[11]),
+            e2=float(vals[12])
+        )
+    elif element_type == "PIPE":
+        return Pipe(
+            **base_params,
+            radius_x=float(vals[10]),
+            radius_y=float(vals[11]),
+            thickness=float(vals[12])
+        )
+    elif element_type == "WIGGLER":
+        return Wiggler(
+            **base_params,
+            radius_x=float(vals[10]),
+            radius_y=float(vals[11])
+        )
+    else:
+        return Element(**base_params)
+
+
+def import_lattice(file):
+    with open(file, "r") as f:
+        next(f)  # Skip the header line
+        lat = [map_table_element(line) for line in f]
+    return lat

--- a/bpy_lattice/lattice.py
+++ b/bpy_lattice/lattice.py
@@ -10,8 +10,6 @@ from bpy_lattice import slicer
 from bpy_lattice import materials
 from .constants import ELE_COLOR, ELE_X_SCALE, ELE_X_SCALE_FACTOR
 
-# bpy.context.scene.render.engine = 'CYCLES'
-
 
 def ele_material(ele):
     key = ele["key"]
@@ -25,7 +23,6 @@ def map_table_dict(line):
     print("map_table_dict: ", line)
     d = {}
     vals = line.split(",")[0:14]
-    # d['layer']  = vals[0].strip()
     d["name"] = vals[0].strip()
     d["index"] = int(vals[1])
     d["x"] = float(vals[2])
@@ -47,7 +44,6 @@ def map_table_dict(line):
     if d["key"] == "WIGGLER":
         d["radius_x"] = float(vals[10])
         d["radius_y"] = float(vals[11])
-        # d['xray_line_len'] =  float(vals[12])
     d["descrip"] = vals[13]
     return d
 
@@ -111,7 +107,6 @@ def faces_from(sections, closed=True):
             )
         faces.append((i0 * n + n - 1, (i0 + 1) * n + n - 1, (i0 + 1) * n, i0 * n))
     if closed:
-        # faces.append(range(n)) #first section
         faces.append(list(reversed(range(n))))  # first section
         faces.append(
             range((len(sections) - 1) * n, (len(sections) - 1) * n + n)
@@ -162,7 +157,6 @@ def ele_section(s_rel, ele):
         m1 = Matrix.Translation((0, rho, 0))
         m2 = Matrix.Rotation(-s_rel / rho, 4, "Z")
         m3 = Matrix.Translation((0, -rho, 0))
-        # m=m3*m2*m1*m0 Old syntax
         m = m3 @ m2 @ m1 @ m0
         sec = []
         for p in s0:
@@ -202,24 +196,11 @@ def ele_mesh(ele):
 
     mesh = bpy.data.meshes.new(name)
     mesh.from_pydata(verts, [], faces)
-    # Fix normals
-    # bpy.ops.object.editmode_toggle()
-    # bpy.ops.mesh.normals_make_consistent(inside=False)
-    # bpy.ops.object.editmode_toggle()
-    # print('mesh update')
     mesh.update(calc_edges=True)
-    # print('calc_normals')
-    # mesh.calc_normals()
-    # print('calc_normals DONE')
     return mesh
 
 
 # ------ Pipe stuff
-
-
-# basic pipe:
-# ele = {'name':'xxx', 'L':0.1, 'key':'PIPE', 'radius_x':0.3, 'radius_y':0.3, 'thickness':0.01}
-
 
 def rotate_mesh(mesh, mat=Matrix.Rotation(pi / 2, 4, "Y")):
     for v in mesh.vertices:
@@ -230,14 +211,10 @@ def new_ellipse(radius_x=1, radius_y=1, length=1, vertices=32):
     bpy.ops.mesh.primitive_cylinder_add(
         radius=radius_x, depth=length, vertices=vertices
     )
-    # bpy.ops.transform.rotate(value=pi/2, axis=(0, 1, 0))
     ob = bpy.context.scene.objects.active
     mesh = ob.data
     for v in mesh.vertices:
         v.co[0] *= radius_y / radius_x
-
-    # ob.rotation_euler[1] = pi/2 # Align to x-axis
-
     return ob
 
 
@@ -246,7 +223,6 @@ def pipe_object(ele):
     ele0 = ele.copy()
     ele0["thickness"] = 0
     ele0["L"] = ele["L"] * 1.1  # the punch needs to be slightly longer to work
-    # ele['thickness']  = 0.2
     mesh0 = ele_mesh(ele0)
     mesh = ele_mesh(ele)
     print("pipe mesh vertices: ", len(mesh0.vertices), len(mesh.vertices))
@@ -257,31 +233,10 @@ def pipe_object(ele):
     object = bpy.data.objects.new(ele["name"], mesh)
 
     # add to scene to
-    # bpy.context.scene.objects.link(object0)
-    # bpy.context.scene.objects.link(object)
     bpy.context.collection.objects.link(object0)
     bpy.context.collection.objects.link(object)
-    # punch_hole(object,object0)
 
-    ## TEMP
     return object
-
-    slicer.slice_object(object, object0)
-
-    # o = bpy.data.objects['xxx']
-    # p = bpy.data.objects['dummy']
-    # slice.slice(o, p)
-
-    bpy.context.scene.objects.unlink(object0)
-
-    bpy.data.objects.remove(object0)
-    bpy.data.meshes.remove(mesh0)
-
-    # fix_mesh(mesh)
-    # for testing:
-    # bpy.context.scene.objects.link(object0)
-    return object
-
 
 # ------------------------------------------
 
@@ -314,7 +269,6 @@ def add_children_from_blend(parent, blendfilepath, libdict):
         children = load_blend(blendfilepath)
         libdict[blendfilepath] = children
     for child in children:
-        # bpy.context.scene.objects.link(child) OLD blender
         bpy.context.collection.objects.link(child)
         if child.parent is None:
             child.parent = parent
@@ -355,7 +309,6 @@ def ele_object(
         # bpy.context.scene.objects.link(object) old blender
         bpy.context.collection.objects.link(object)
 
-        # fix_mesh(object)
     object.location = (0, 0, 0)
     bfile = blendfile(ele)
     if bfile and use_real_model and catalogue:
@@ -374,13 +327,10 @@ def ele_object(
             print("Blend file missing: ", f)
 
     mat = ele_material(ele)
-    # print('color: ', color)
     mat.diffuse_color = ele_color(ele) + tuple([1])
     object.data.materials.append(mat)
 
     return object
-
-    # bpy.context.scene.objects.link(object)
 
 
 def ele_objects(
@@ -394,7 +344,6 @@ def ele_objects(
     """
     Create multiple objects from a list of eles (a lattice)
     """
-    print("here 2")
     Xcenter, Ycenter, Zcenter = origin
 
     objects = []

--- a/bpy_lattice/lattice.py
+++ b/bpy_lattice/lattice.py
@@ -4,7 +4,7 @@ import os
 import re
 from mathutils import Matrix, Vector
 from math import sin, cos, pi
-
+from typing import Tuple, Optional
 
 from bpy_lattice import slicer
 from bpy_lattice import materials
@@ -297,25 +297,31 @@ def old_fix_mesh(object):
 
 
 def ele_object(
-    ele, library, use_real_model=False, catalogue=None, hide_real_model=True
+    ele, 
+    library: dict = {},
+    use_real_model: bool = False,
+    catalogue: Optional[str] = None,
+    hide_real_model: bool = True,
 ):
-    name = ele["name"]
-    print("Object: ", name)
+    print("Object: ", ele["name"])
+    
+    # Generate the "simple" model
     if ele["key"] == "PIPE" and ele["thickness"] > 0 and ele["radius_x"] > 0:
         object = pipe_object(ele)
     else:
         mesh = ele_mesh(ele)
-        object = bpy.data.objects.new(name, mesh)
-        # bpy.context.scene.objects.link(object) old blender
+        object = bpy.data.objects.new(ele["name"], mesh)
         bpy.context.collection.objects.link(object)
-
     object.location = (0, 0, 0)
+    
+    # Load blender model of element
     bfile = blendfile(ele)
     if bfile and use_real_model and catalogue:
         f = os.path.join(catalogue, bfile)
         if os.path.isfile(f):
             print("blend file: ", f, "exists!")
             add_children_from_blend(object, f, library)
+
             # Hide options for preview
             if hide_real_model:
                 for c in object.children:
@@ -334,12 +340,12 @@ def ele_object(
 
 
 def ele_objects(
-    eles,
-    library={},
-    use_real_model=False,
-    catalogue=None,
-    hide_real_model=True,
-    origin=(0, 0, 0),
+    eles: list,
+    library: dict = {},
+    use_real_model: bool = False,
+    catalogue: Optional[str] = None,
+    hide_real_model: bool = True,
+    origin: Tuple[float, float, float] = (0, 0, 0),
 ):
     """
     Create multiple objects from a list of eles (a lattice)

--- a/bpy_lattice/lattice.py
+++ b/bpy_lattice/lattice.py
@@ -8,7 +8,7 @@ from math import sin, cos, pi
 
 from bpy_lattice import slicer
 from bpy_lattice import materials
-
+from .constants import ELE_COLOR, ELE_X_SCALE, ELE_X_SCALE_FACTOR
 
 # bpy.context.scene.render.engine = 'CYCLES'
 
@@ -65,43 +65,6 @@ def import_lattice(file):
         next(f)  # Skip the header line
         lat = [map_table_dict(line) for line in f]
     return lat
-
-
-ELE_X_SCALE_FACTOR = 50
-
-
-ELE_X_SCALE = {
-    "MARKER": 0.001,
-    "E_GUN": 0.4,
-    "PIPE": 0.01,
-    "DRIFT": 0.01,
-    "ECOLLIMATOR": 0.03,
-    "RCOLLIMATOR": 0.03,
-    "SBEND": 0.02,
-    "QUADRUPOLE": 0.03,
-    "SEXTUPOLE": 0.02,
-    "LCAVITY": 0.1,
-    "RFCAVITY": 0.5,
-    "SOLENOID": 0.1,
-    "WIGGLER": 0.04,
-    "EM_FIELD": 0.1,
-    "INSTRUMENT": 0.05,
-}
-
-
-ELE_COLOR = {
-    "PIPE": (1, 1, 1),
-    "E_GUN": (0.5, 0.5, 0.5),
-    "SBEND": (1, 0, 0),
-    "QUADRUPOLE": (0, 0, 1),
-    "LCAVITY": (0, 1, 0),
-    "RFCAVITY": (0, 1, 0),
-    "SOLENOID": (1, 0, 1),  # purple
-    "EM_FIELD": (1, 0, 0.5),  # ??
-    "SEXTUPOLE": (1, 1, 0),  # yellow
-    "WIGGLER": (1, 0.4, 0),  # orange?
-    "INSTRUMENT": (0, 0, 0),
-}  # black
 
 
 def ele_x_scale(ele):


### PR DESCRIPTION
This PR adds a new option to the import function to avoid importing "simple" models when a CAD model exists for an element. This is important when programs downstream of blender use the data and don't necessarily respect visibility settings. Other changes follow.

- Elements are refactored to be passed as dataclasses instead of dicts now, this gives type information while developing code among other benefits.
- Commented out old code has been removed
- Type annotation was added to some common functions
- The pipe "dummy" objects used for cutting the interior of pipes (which seemed to be deprecated) are no longer imported into scene
- Constants are now in separate file