### PR TITLE
Tweak install script suggestions (target branch - `add_bmad_interface`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,9 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [
-  "setuptools>=60",
-  "setuptools_scm[toml]>=8.0"
-]
+requires = ["setuptools>=60", "setuptools_scm[toml]>=8.0"]
 
 [project]
-authors = [
-  {name="Christopher Mayes"},
-]
+authors = [{ name = "Christopher Mayes" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Natural Language :: English",
@@ -20,22 +15,18 @@ dependencies = [
   "bpy",
 ]
 description = "Tools for creating particle accelerator models in Blender"
-dynamic = [ "version" ]
+dynamic = ["version"]
 keywords = []
 name = "bpy-lattice"
-readme = {file = "README.md", content-type = "text/markdown"}
+readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"
 
 [project.urls]
 Homepage = "https://github.com/ChristopherMayes/bpy-lattice"
 
-[options]
-zip_safe = false
-include_package_data = true
-
 [tool.setuptools.packages.find]
 where = ["."]
-include = [ "bpy_lattice*", ]
+include = ["bpy_lattice*"]
 namespaces = false
 
 [project.license]

--- a/scripts/install_blender_package.sh
+++ b/scripts/install_blender_package.sh
@@ -14,25 +14,24 @@ list_blender_versions() {
 show_help() {
   echo "Usage: $0 <blender_version> <path_to_local_package> [--editable]"
   echo
-  echo "This script installs a local Python package into Blender's Python environment."
+  echo "This script installs bpy-lattice into Blender's Python environment."
   echo
   echo "Arguments:"
   echo "  <blender_version>          The version of Blender to target (e.g., 4.2)."
-  echo "  <path_to_local_package>    The path to the local Python package to install."
   echo "  [--editable]               Optional flag to install the package in editable mode."
   echo
   echo "Base Path: $BASE_PATH"
   echo "Modules Path: $MODULES_PATH"
   echo
   echo "Examples:"
-  echo "  $0 4.2 /path/to/your/package"
-  echo "  $0 4.2 /path/to/your/package --editable"
+  echo "  $0 4.2"
+  echo "  $0 4.2 --editable"
   echo
   echo "This script also lists available Blender versions if arguments are missing or incorrect."
 }
 
 # Check if at least two arguments are provided
-if [ -z "$1" ] || [ -z "$2" ]; then
+if [ -z "$1" ]; then
   BASE_PATH="/Users/$(whoami)/Library/Application Support/Blender"
   MODULES_PATH="$BASE_PATH/<version>/scripts/modules"
   show_help
@@ -41,10 +40,14 @@ if [ -z "$1" ] || [ -z "$2" ]; then
 fi
 
 BLENDER_VERSION=$1
-PACKAGE_PATH=$2
-EDITABLE_FLAG=$3
+EDITABLE_FLAG=$2
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+GIT_SOURCE_DIR=$(cd $SCRIPT_DIR/.. && pwd)
+BPY_LATTICE_PACKAGE_DIR="$GIT_SOURCE_DIR/bpy_lattice"
 BASE_PATH="/Users/$(whoami)/Library/Application Support/Blender/$BLENDER_VERSION"
 MODULES_PATH="$BASE_PATH/scripts/modules"
+DEST_MODULE_PATH="$BASE_PATH/scripts/modules/bpy_lattice"
 
 # Check if the base path exists
 if [ ! -d "$BASE_PATH" ]; then
@@ -65,13 +68,17 @@ fi
 # Create the modules directory if it doesn't exist
 mkdir -p "$MODULES_PATH"
 
-# Determine the install command
-INSTALL_BASE_COMMAND="$PYTHON_EXEC -m pip install --no-deps --ignore-installed --target=\"$MODULES_PATH\""
+# Clean previous installations
+if [[ -d "$DEST_MODULE_PATH" || -L "$DEST_MODULE_PATH" ]]; then
+  rm -rf "$DEST_MODULE_PATH"* "$MODULES_PATH/bin/bmad-to-blender"
+  echo "* Cleaned previous installation of bpy-lattice"
+fi
 
-if [ "$EDITABLE_FLAG" == "--editable" ]; then
-  INSTALL_COMMAND="$INSTALL_BASE_COMMAND -e \"$PACKAGE_PATH\""
+# Determine the install command
+if [ "$EDITABLE_FLAG" == "--editable" ] || [ "$EDITABLE_FLAG" == "-e" ]; then
+  INSTALL_COMMAND="ln -sf \"$BPY_LATTICE_PACKAGE_DIR\" \"$MODULES_PATH\""
 else
-  INSTALL_COMMAND="$INSTALL_BASE_COMMAND \"$PACKAGE_PATH\""
+  INSTALL_COMMAND="$PYTHON_EXEC -m pip install --no-deps --upgrade --target=\"$MODULES_PATH\" \"$GIT_SOURCE_DIR\""
 fi
 
 echo "Installing with command: $INSTALL_COMMAND"

--- a/scripts/install_blender_package.sh
+++ b/scripts/install_blender_package.sh
@@ -52,35 +52,31 @@ if [ ! -d "$BASE_PATH" ]; then
   exit 1
 fi
 
-# Create the modules directory if it doesn't exist
-mkdir -p "$MODULES_PATH"
-
 # Find the Python executable within the specified Blender version path
 BLENDER_APP_PATH="/Applications/Blender.app/Contents/Resources/$BLENDER_VERSION/python/bin"
 PYTHON_EXEC=$(find "$BLENDER_APP_PATH" -name "python3.*" 2>/dev/null | head -n 1)
 
 # Check if the Python executable was found
-if [ -z "$PYTHON_EXEC" ]; then
+if [ ! -x "$PYTHON_EXEC" ]; then
   echo "Blender Python executable not found for version $BLENDER_VERSION"
   exit 1
 fi
 
-# Ensure pip is available
-"$PYTHON_EXEC" -m ensurepip
-
-# Upgrade pip to the latest version
-"$PYTHON_EXEC" -m pip install --upgrade pip
+# Create the modules directory if it doesn't exist
+mkdir -p "$MODULES_PATH"
 
 # Determine the install command
+INSTALL_BASE_COMMAND="$PYTHON_EXEC -m pip install --no-deps --ignore-installed --target=\"$MODULES_PATH\""
+
 if [ "$EDITABLE_FLAG" == "--editable" ]; then
-  INSTALL_COMMAND="$PYTHON_EXEC -m pip install --no-deps --ignore-installed -e --target=\"$MODULES_PATH\" \"$PACKAGE_PATH\""
+  INSTALL_COMMAND="$INSTALL_BASE_COMMAND -e \"$PACKAGE_PATH\""
 else
-  INSTALL_COMMAND="$PYTHON_EXEC -m pip install --no-deps --ignore-installed --target=\"$MODULES_PATH\" \"$PACKAGE_PATH\""
+  INSTALL_COMMAND="$INSTALL_BASE_COMMAND \"$PACKAGE_PATH\""
 fi
 
 echo "Installing with command: $INSTALL_COMMAND"
 
 # Install the local package directly into Blender's scripts/modules directory
-eval $INSTALL_COMMAND
+eval $INSTALL_COMMAND || exit
 
 echo "Custom Python package installed into: $MODULES_PATH"


### PR DESCRIPTION
# Install script change

Blender gives you a specific path to put modules in but doesn't let you put modules in site-packages (as far as I'm aware). This means that the editable installs from pip which generate `.pth` files are ignored, as the search path is only updated with `site-packages/*.pth` files (among a few others) and not from anywhere on `PYTHONPATH`.

### Configuration Updates:
* Removed invalid `[options]` section and reformatted `pyproject.toml` for consistency.

### Script Improvements:
* Updated help message in `scripts/install_blender_package.sh` to reflect the specific installation of `bpy-lattice` and removed the requirement for the local package path argument.
* Modified the script to handle the absence of the second argument and adjusted the installation command to support editable mode and clean previous installations. (`-e` or `--editable`)